### PR TITLE
feat: 🎸 adding revalidation to the blog route

### DIFF
--- a/payload.config.ts
+++ b/payload.config.ts
@@ -38,7 +38,7 @@ export default buildConfig({
     autoLogin: {
       email: 'dev@payloadcms.com',
       password: 'test',
-      prefillOnly: true,
+      // prefillOnly: true,
     },
   },
   async onInit(payload) {

--- a/src/app/actions/blog.ts
+++ b/src/app/actions/blog.ts
@@ -3,12 +3,14 @@
 import { getPayload } from 'payload'
 import configPromise from '@payload-config'
 import { Post } from 'payload-types'
+import { revalidatePath } from 'next/cache'
 
 const payload = await getPayload({
   config: configPromise,
 })
 
 export async function getPostsCollection() {
+  revalidatePath('/blog', 'page')
   try {
     const collection = await payload.find({
       collection: 'posts',


### PR DESCRIPTION
## Problem
Blog posts when created were not appearing i nthe front end.

## Reason
Route data was only generated at buiild/deployment and so the static pages were never refreshing the cache.

## How

Added revalidatePath from next/cache
Each route load will dump cache and pull data. 

## Note

Need to improve this in future but this will fix fine for now.
